### PR TITLE
Fix page not found errors with broken redirect pages

### DIFF
--- a/wikichain.html
+++ b/wikichain.html
@@ -84,7 +84,13 @@
 					
 					if ('error' in json) {
 						if (json['error']['code'] == 'missingtitle') {
-							alert('Page not found');
+							if (document.forms[0][2].value == chainLength+1) {
+								//Check if it's the starting page that is the one not found
+								alert('Start page not found');
+							} else {
+								loadRandom(window.wikiUrl);
+								return;
+							}
 						} else {
 							alert('API error: ' + json['error']['info']);
 						}


### PR DESCRIPTION
Redirect pages on wikis that lead to non-existent pages will cause the page not found error to be returned. This will fix that and just act like the chain has broken (because it has really), unless it's the first page that is a broken link, in which case it will still error because the user is silly.

Fun tool by the way :)
